### PR TITLE
adding semi-colon to modifiers in wallet.sol, std.sol, and name_reg.sol

### DIFF
--- a/_pre/name_reg.sol
+++ b/_pre/name_reg.sol
@@ -4,7 +4,7 @@ contract owned {
     owner = msg.sender;
   }
   modifier onlyowner() {
-    if (msg.sender==owner) _
+    if (msg.sender==owner) _;
   }
 }
 

--- a/contracts/std.sol
+++ b/contracts/std.sol
@@ -7,7 +7,7 @@ contract owned {
     owner = newOwner;
   }
   modifier onlyowner() {
-    if (msg.sender==owner) _
+    if (msg.sender==owner) _;
   }
 }
 

--- a/contracts/wallet.sol
+++ b/contracts/wallet.sol
@@ -38,14 +38,14 @@ contract multiowned {
     // simple single-sig function modifier.
     modifier onlyowner {
         if (isOwner(msg.sender))
-            _
+            _;
     }
     // multi-sig function modifier: the operation must have an intrinsic hash in order
     // that later attempts can be realised as the same underlying operation and
     // thus count as confirmations.
     modifier onlymanyowners(bytes32 _operation) {
         if (confirmAndCheck(_operation))
-            _
+            _;
     }
 
     // METHODS
@@ -253,7 +253,7 @@ contract daylimit is multiowned {
     // simple modifier for daily limit.
     modifier limitedDaily(uint _value) {
         if (underLimit(_value))
-            _
+            _;
     }
 
     // METHODS


### PR DESCRIPTION
Hello,
I just started using the ether studio and tried executing the wallet demo found from:
https://www.gitbook.com/book/nogo10/ether-camp-live-studio-primer/

When I compiled the contracts, I got the following error:
Could not start sandbox: Compilation error: _pre/name_reg.sol:8:3: Error: Expected token Semicolon got 'RBrace' } ^

I added in the semi-colon in all the modifiers in name_reg.sol, std.sol, and wallet.sol